### PR TITLE
fixed: type error in chatReducer

### DIFF
--- a/store/reducers/ChatReducer.ts
+++ b/store/reducers/ChatReducer.ts
@@ -13,6 +13,7 @@ export const chatReducer = (
         messages: [
           ...state.messages,
           {
+            id: action.payload.id,
             sender: action.payload.sender,
             message: action.payload.message,
             time: new Date(Date.now()),


### PR DESCRIPTION
There was a type error in the chatReducer which was not returning the id of the chat due to which the builds were failing.
The appropriate types have been passed in the chatReducer.